### PR TITLE
silence errors when running it:test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import Dependencies._
-import sbt.Resolver
 
 lazy val commonTestDependencies = Seq(
   scalaTest,

--- a/kafka-library/src/it/scala/com/tenable/library/kafkaclient/client/standard/KafkaAdminIOSpec.scala
+++ b/kafka-library/src/it/scala/com/tenable/library/kafkaclient/client/standard/KafkaAdminIOSpec.scala
@@ -1,6 +1,7 @@
 package com.tenable.library.kafkaclient.client.standard
 
 import cats.effect.IO
+import com.github.ghik.silencer.silent
 import org.apache.kafka.clients.admin.{NewPartitions, TopicListing}
 import com.tenable.library.kafkaclient.testhelpers.{GeneralKafkaHelpers, SyncIntegrationSpec}
 
@@ -10,6 +11,7 @@ import scala.concurrent.duration.DurationInt
 import net.manub.embeddedkafka.EmbeddedKafka
 import org.scalatest.BeforeAndAfterAll
 
+@silent
 class KafkaAdminIOSpec extends SyncIntegrationSpec with EmbeddedKafka with BeforeAndAfterAll {
   import GeneralKafkaHelpers._
   implicit val timer = IO.timer(ExecutionContext.global)

--- a/kafka-library/src/it/scala/com/tenable/library/kafkaclient/client/standard/consumer/KafkaConsumerSpec.scala
+++ b/kafka-library/src/it/scala/com/tenable/library/kafkaclient/client/standard/consumer/KafkaConsumerSpec.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import cats.syntax.apply._
 import com.tenable.library.kafkaclient.client.standard.consumer.actions.ProcessAction
-import com.tenable.library.kafkaclient.config.{KafkaConsumerConfig}
+import com.tenable.library.kafkaclient.config.KafkaConsumerConfig
 import com.tenable.library.kafkaclient.testhelpers.AsyncIntegrationSpec
 import com.tenable.library.kafkaclient.testhelpers.GeneralKafkaHelpers._
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -19,6 +19,7 @@ import cats.effect.IO
 import cats.syntax.applicativeError._
 import cats.instances.list._
 import cats.syntax.traverse._
+import com.github.ghik.silencer.silent
 import com.tenable.library.kafkaclient.client.standard.KafkaConsumerIO
 import com.tenable.library.kafkaclient.client.standard.consumer.units.TPBatch.TPRecords
 
@@ -44,6 +45,7 @@ class TestPartitioner2Partitions extends Partitioner {
   override def configure(configs: util.Map[String, _]): Unit = ()
 }
 
+@silent
 class KafkaConsumerSpec extends AsyncIntegrationSpec with EmbeddedKafka with BeforeAndAfterAll {
   override implicit val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = 20.seconds, interval = 500.millis)


### PR DESCRIPTION
When running
```bash
sbt +it:test
```
I got errors like so
```
[error] (....)/Kastle/kafka-library/src/it/scala/com/tenable/library/kafkaclient/client/standard/consumer/KafkaConsumerSpec.scala:399:16: object JavaConverters in package collection is deprecated (since 2.13.0): Use `scala.jdk.CollectionConverters` instead
[error]       .iterator()
[error]                ^
```
Using `scala.jdk.CollectionConverters` in 2.12.x is not an option so it looks like silence needs to be added.