### PR TITLE
Upgrade scala versions and silencer plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val commonTestDependencies = Seq(
 
 inThisBuild(
   List(
-    scalaVersion := "2.12.12",
+    scalaVersion := "2.13.3",
     crossScalaVersions := Seq("2.12.12", "2.13.3"),
     organization := "com.tenable",
     organizationName := "Tenable",

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ lazy val commonTestDependencies = Seq(
 
 inThisBuild(
   List(
-    scalaVersion := "2.12.10",
-    crossScalaVersions := Seq("2.12.10", "2.13.1"),
+    scalaVersion := "2.12.12",
+    crossScalaVersions := Seq("2.12.12", "2.13.3"),
     organization := "com.tenable",
     organizationName := "Tenable",
     organizationHomepage := Some(url("https://www.tenable.com/")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   lazy val logbackClassic    = "ch.qos.logback" % "logback-classic" % logbackVersion
   lazy val logbackRelated    = Seq(logbackClass, logbackClassic)
 
-  lazy val silencerVersion = "1.6.0"
+  lazy val silencerVersion = "1.7.1"
   lazy val silencerPlugin  = "com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full
   lazy val kindProjector   = "org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.2

--- a/src/main/scala/com/tenable/library/kafkaclient/client/standard/consumer/ConsumerStateHandler.scala
+++ b/src/main/scala/com/tenable/library/kafkaclient/client/standard/consumer/ConsumerStateHandler.scala
@@ -133,7 +133,7 @@ private[standard] class ConsumerStateHandler[F[_]: ConcurrentEffect: ContextShif
     F.start {
       F.cancelable[Unit] { _ =>
         val fiberF = F.start(keepAliveF.foreverM[Unit])
-        val fiber  = F.toIO(fiberF).unsafeRunSync
+        val fiber  = F.toIO(fiberF).unsafeRunSync()
 
         for {
           _ <- F.delay(logger.info("Cancelling keep-alive"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.0"
+version in ThisBuild := "0.8.0"


### PR DESCRIPTION
will allow kastle to be used in 2.13.3 projects

<!--Please note that a new version of the library will not be published until the version.sbt file is updated.-->
